### PR TITLE
feat: Update Gradle configuration to exclude kotlin-compiler-embeddable and set JVM target

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
-    alias(libs.plugins.kotlin.jvm)
 }
 
 group = "io.jenkins.gradle.conventions"
@@ -98,11 +97,15 @@ gradlePlugin {
 
 dependencies {
     implementation(gradleApi())
-    implementation(gradleKotlinDsl())
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.kotlin.reflect)
-    implementation(libs.kotlin.gradle.plugin)
     implementation(libs.spotless.gradle.plugin)
-    implementation(libs.detekt.gradle.plugin)
-    implementation(libs.ktlint.gradle.plugin)
+    implementation(libs.detekt.gradle.plugin) {
+        exclude("org.jetbrains.kotlin", "kotlin-compiler-embeddable")
+    }
+    implementation(libs.ktlint.gradle.plugin) {
+        exclude("org.jetbrains.kotlin", "kotlin-compiler-embeddable")
+    }
+
+    compileOnly(libs.kotlin.gradle.plugin) {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
+    }
 }

--- a/build-logic/src/main/kotlin/conventions/QualityConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/conventions/QualityConventionsPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 public class QualityConventionsPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -111,7 +112,7 @@ private fun Project.configureDetekt(libs: VersionCatalog) {
     }
 
     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-        jvmTarget = "17"
+        jvmTarget = JvmTarget.JVM_17.target
         autoCorrect = false
 
         reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,9 @@
 plugins {
     base
     alias(libs.plugins.kotlin.jvm) apply false
+    id("conventions.java")
+    id("conventions.kotlin")
+    id("conventions.quality")
 }
 
 tasks.named<Wrapper>("wrapper") {

--- a/convention-plugin/build.gradle.kts
+++ b/convention-plugin/build.gradle.kts
@@ -24,7 +24,9 @@ description = "Gradle plugin that provides conventions for developing Jenkins pl
 dependencies {
     compileOnly(gradleApi())
     compileOnly(gradleKotlinDsl())
-    compileOnly(libs.kotlin.gradle.plugin)
+    compileOnly(libs.kotlin.gradle.plugin) {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
+    }
     implementation(libs.jenkins.gradle.jpi2)
 
     implementation(libs.spotless.gradle.plugin)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,8 +26,6 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
-
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)


### PR DESCRIPTION
Fixes #54 

# Summary

This pull request primarily focuses on improving dependency management and code consistency across the Gradle build scripts. Key changes include removing unused Kotlin plugin dependencies, excluding problematic modules from certain dependencies, and standardizing the JVM target configuration.

### Dependency Management Improvements:

* [`build-logic/build.gradle.kts`](diffhunk://#diff-f714fa5f754f0da54abb877f8cf4e3de6341ad321db5f4c697fa602a5da8e4b4L101-R110): Removed unused Kotlin plugin dependencies and excluded the `kotlin-compiler-embeddable` module from `detekt`, `ktlint`, and `kotlin.gradle.plugin` dependencies to avoid potential conflicts.
* [`convention-plugin/build.gradle.kts`](diffhunk://#diff-aaea7e9e31c10d8b0d331e79a0b4eee507076e9d7463a4339d4fbeda97ba37e0L27-R29): Updated the `libs.kotlin.gradle.plugin` dependency to exclude the `kotlin-compiler-embeddable` module.

### Code Consistency Enhancements:

* [`build-logic/src/main/kotlin/conventions/QualityConventionsPlugin.kt`](diffhunk://#diff-dfc73465aad19ee272a344b895d16e0f8fb1b3416d1f8de3d63d1b91479f0bd9L114-R115): Standardized the JVM target configuration by replacing the hardcoded `"17"` value with `JvmTarget.JVM_17.target`.
* [`settings.gradle.kts`](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dL29-L30): Removed the `enableFeaturePreview("STABLE_CONFIGURATION_CACHE")` feature preview, potentially simplifying the configuration.

### Cleanup:

* [`build-logic/build.gradle.kts`](diffhunk://#diff-f714fa5f754f0da54abb877f8cf4e3de6341ad321db5f4c697fa602a5da8e4b4L21): Removed the `alias(libs.plugins.kotlin.jvm)` plugin, as it is no longer needed.