### PR TITLE
Update publish-version-catalog.yml

### DIFF
--- a/.github/workflows/publish-version-catalog.yml
+++ b/.github/workflows/publish-version-catalog.yml
@@ -24,7 +24,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Publish to Maven Central
-        run: ./gradlew publish
+        run: ./gradlew publish --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
Add --no-configuration-cache flag

## Summary
This pull request includes a minor update to the `.github/workflows/publish-version-catalog.yml` file. The change modifies the Gradle command used for publishing to Maven Central to disable the configuration cache.

* [`.github/workflows/publish-version-catalog.yml`](diffhunk://#diff-5bc2ad4a659419a58faf7579d537c106dc2753ff7697277df56234fd4f617425L27-R27): Updated the `run` command to use `./gradlew publish --no-configuration-cache` instead of `./gradlew publish` to ensure compatibility during the publishing process.

Fixes #58 

---

## What Changed?

<!--
- List key changes and improvements.
- Note any relevant dependencies or related PRs.
- Use bullet points for readability.
-->

- 

---

## Change Type
- [X] Build/CI/CD improvement