### PR TITLE
feat: Update tags for Jenkins Gradle Convention Plugin to improve categorization

### DIFF
--- a/convention-plugin/build.gradle.kts
+++ b/convention-plugin/build.gradle.kts
@@ -56,7 +56,16 @@ gradlePlugin {
             id = "io.github.aaravmahajanofficial.jenkins-gradle-convention-plugin"
             displayName = "Jenkins Gradle Convention Plugin"
             description = "Convention plugin for developing Jenkins plugins with Gradle"
-            tags = listOf("jenkins", "gradle-plugin", "convention-plugin", "plugin", "ci-cd")
+            tags =
+                listOf(
+                    "jenkins",
+                    "convention-plugin",
+                    "jenkins-plugin-development",
+                    "build-automation",
+                    "standardization",
+                    "build-logic",
+                    "version-catalog",
+                )
             implementationClass = "JenkinsConventionPlugin"
         }
     }


### PR DESCRIPTION
## Summary

This pull request updates the tags in the `gradlePlugin` block of `convention-plugin/build.gradle.kts` to better reflect the purpose and functionality of the Jenkins Gradle Convention Plugin.

Key change:

* Updated the `tags` list to include more descriptive and relevant terms, such as "jenkins-plugin-development", "build-automation", "standardization", "build-logic", and "version-catalog", while removing less specific tags like "gradle-plugin" and "plugin".