### PR TITLE
refactor: switch from googleJavaFormat to palantirJavaFormat

### DIFF
--- a/build-logic/src/main/kotlin/conventions/QualityConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/conventions/QualityConventionsPlugin.kt
@@ -64,7 +64,7 @@ private fun Project.configureSpotless() {
             )
         }
         java {
-            googleJavaFormat()
+            palantirJavaFormat()
             target("src/*/java/**/*.java")
             targetExclude("**/generated/**", "**/build/**", "**/.gradle/**")
             trimTrailingWhitespace()

--- a/convention-plugin/src/main/kotlin/internal/QualityManager.kt
+++ b/convention-plugin/src/main/kotlin/internal/QualityManager.kt
@@ -280,7 +280,7 @@ public class QualityManager(
             java {
                 it.target("src/*/java/**/*.java")
                 it.targetExclude("**/generated/**", "**/build/**", "**/.gradle/**")
-                it.googleJavaFormat()
+                it.palantirJavaFormat()
                 it.trimTrailingWhitespace()
                 it.endWithNewline()
                 it.removeUnusedImports()


### PR DESCRIPTION
## Summary

This pull request updates the Java formatting tool used in the project from Google Java Format to Palantir Java Format. The changes ensure consistency in code style configurations across the project.

### Java formatting tool update:
* In `QualityConventionsPlugin.kt`, replaced `googleJavaFormat()` with `palantirJavaFormat()` in the `configureSpotless` method to apply the Palantir Java Format for formatting Java files.
* In `QualityManager.kt`, updated the Java formatting tool from `googleJavaFormat()` to `palantirJavaFormat()` in the configuration of the `java` block for code quality management.


---