### PR TITLE
fix: update version constants to use BOM suffix in configuration

### DIFF
--- a/convention-plugin/src/main/kotlin/JenkinsConventionPlugin.kt
+++ b/convention-plugin/src/main/kotlin/JenkinsConventionPlugin.kt
@@ -46,7 +46,7 @@ public class JenkinsConventionPlugin : Plugin<Project> {
                 KotlinConventionManager(project, libs).configure()
             }
             project.plugins.withId("groovy") {
-                GroovyConventionManager(project, libs).configure()
+                GroovyConventionManager(project).configure()
             }
 
             JpiPluginAdapter(project, pluginExtension).applyAndConfigure()

--- a/convention-plugin/src/main/kotlin/extensions/BomExtension.kt
+++ b/convention-plugin/src/main/kotlin/extensions/BomExtension.kt
@@ -237,7 +237,7 @@ public open class GuavaBomExtension
             objects.property<Boolean>().convention(
                 gradleProperty(
                     providers,
-                    ConfigurationConstants.GUAVA_VERSION,
+                    ConfigurationConstants.GUAVA_BOM,
                     String::toBoolean,
                 ).orElse(true),
             )
@@ -257,7 +257,7 @@ public open class Log4JBomExtension
             objects.property<Boolean>().convention(
                 gradleProperty(
                     providers,
-                    ConfigurationConstants.LOG4J_VERSION,
+                    ConfigurationConstants.LOG4J_BOM,
                     String::toBoolean,
                 ).orElse(true),
             )
@@ -277,7 +277,7 @@ public open class VertxBomExtension
             objects.property<Boolean>().convention(
                 gradleProperty(
                     providers,
-                    ConfigurationConstants.VERTX_VERSION,
+                    ConfigurationConstants.VERTX_BOM,
                     String::toBoolean,
                 ).orElse(true),
             )

--- a/convention-plugin/src/main/kotlin/internal/GroovyConventionManager.kt
+++ b/convention-plugin/src/main/kotlin/internal/GroovyConventionManager.kt
@@ -16,16 +16,13 @@
 package internal
 
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.tasks.compile.GroovyCompile
-import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
 
 private const val JAVA_VERSION = 17
 
 public class GroovyConventionManager(
     private val project: Project,
-    private val libs: VersionCatalog,
 ) {
     public fun configure() {
         project.plugins.withId("groovy") {
@@ -34,11 +31,6 @@ public class GroovyConventionManager(
                 it.groovyOptions.optimizationOptions?.put("indy", true)
                 it.options.release.set(JAVA_VERSION)
                 it.options.compilerArgs.addAll(listOf("-parameters"))
-            }
-
-            project.dependencies {
-                add("compileOnly", platform(libs.findLibrary("groovy-bom").get()))
-                add("compileOnly", libs.findLibrary("groovy").get())
             }
         }
     }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "automerge": true,
+  "automergeType": "branch"
 }


### PR DESCRIPTION
## Summary & What Changed?

Fix the Bom suffix & enable the Renovate Bot `automerge`