### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: CI
+permissions:
+  contents: read
+  packages: write
+  actions: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aaravmahajanofficial/jenkins-gradle-convention-plugin/security/code-scanning/2](https://github.com/aaravmahajanofficial/jenkins-gradle-convention-plugin/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository contents.
- `packages: write` for publishing to Maven Local.
- `actions: read` for caching and using actions.

The `permissions` block will be added after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
