### PR TITLE
refactor: simplify TestProjectBuilder.create method by removing name parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: release-candidate
 
       - name: Build & Test
         run: |

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/BomManagementIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/BomManagementIntegrationTest.kt
@@ -43,7 +43,7 @@ class BomManagementIntegrationTest {
     fun `apply all predefined boms correctly`() {
         builder =
             TestProjectBuilder
-                .create("all-boms-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -89,7 +89,7 @@ class BomManagementIntegrationTest {
     fun `handle test-only boms correctly`() {
         builder =
             TestProjectBuilder
-                .create("all-boms-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -110,7 +110,7 @@ class BomManagementIntegrationTest {
     fun `apply custom bom`() {
         builder =
             TestProjectBuilder
-                .create("custom-boms-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -160,7 +160,7 @@ class BomManagementIntegrationTest {
     fun `fail on custom bom missing coordinates`() {
         builder =
             TestProjectBuilder
-                .create("custom-boms-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -206,7 +206,7 @@ class BomManagementIntegrationTest {
     fun `fail on custom bom missing version`() {
         builder =
             TestProjectBuilder
-                .create("custom-boms-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -252,7 +252,7 @@ class BomManagementIntegrationTest {
     fun `handle bom conflicts gracefully`() {
         builder =
             TestProjectBuilder
-                .create("boms-conflict-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -279,7 +279,7 @@ class BomManagementIntegrationTest {
     fun `disable boms via properties`() {
         builder =
             TestProjectBuilder
-                .create("disable-boms-properties-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withGradleProperties(

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/PluginApplicationIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/PluginApplicationIntegrationTest.kt
@@ -44,7 +44,7 @@ class PluginApplicationIntegrationTest {
     fun `apply plugin to new Kotlin DSL project`() {
         builder =
             TestProjectBuilder
-                .create("kotlin-dsl-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -62,7 +62,7 @@ class PluginApplicationIntegrationTest {
     fun `apply plugin to existing Java project`() {
         builder =
             TestProjectBuilder
-                .create("java-existing-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -89,7 +89,7 @@ class PluginApplicationIntegrationTest {
     fun `validate minimum gradle version`() {
         builder =
             TestProjectBuilder
-                .create("gradle-version-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -105,7 +105,7 @@ class PluginApplicationIntegrationTest {
     fun `apply plugin with property configuration`() {
         builder =
             TestProjectBuilder
-                .create("property-config-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withGradleProperties(
@@ -129,7 +129,7 @@ class PluginApplicationIntegrationTest {
     fun `verify quality tasks conditional creation`() {
         builder =
             TestProjectBuilder
-                .create("quality-conditional-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/QualityToolsIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/QualityToolsIntegrationTest.kt
@@ -44,7 +44,7 @@ class QualityToolsIntegrationTest {
     fun `execute checkstyle with defaults`() {
         builder =
             TestProjectBuilder
-                .create("checkstyle-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -69,7 +69,7 @@ class QualityToolsIntegrationTest {
     fun `checkstyle should skip violations due to suppressions`() {
         builder =
             TestProjectBuilder
-                .create("checkstyle-suppress-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -106,7 +106,7 @@ class QualityToolsIntegrationTest {
     fun `execute spotbugs with defaults`() {
         builder =
             TestProjectBuilder
-                .create("spotbugs-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -148,7 +148,7 @@ class QualityToolsIntegrationTest {
     fun `execute spotbugs with exclude filters`() {
         builder =
             TestProjectBuilder
-                .create("spotbugs-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -198,7 +198,7 @@ class QualityToolsIntegrationTest {
     fun `execute pmd with defaults`() {
         builder =
             TestProjectBuilder
-                .create("pmd-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -241,7 +241,7 @@ class QualityToolsIntegrationTest {
     fun `execute cpd with defaults`() {
         builder =
             TestProjectBuilder
-                .create("cpd-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(basicBuildScript())
@@ -382,7 +382,7 @@ class QualityToolsIntegrationTest {
     fun `execute detekt for kotlin code analysis`() {
         builder =
             TestProjectBuilder
-                .create("detekt-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -430,7 +430,7 @@ class QualityToolsIntegrationTest {
     fun `execute detekt with baseline config`() {
         builder =
             TestProjectBuilder
-                .create("detekt-baseline-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -480,7 +480,7 @@ class QualityToolsIntegrationTest {
     fun `execute spotless with defaults`() {
         builder =
             TestProjectBuilder
-                .create("spotless-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -531,7 +531,7 @@ class QualityToolsIntegrationTest {
     fun `execute dokka with defaults`() {
         builder =
             TestProjectBuilder
-                .create("dokka-test")
+                .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
@@ -573,7 +573,51 @@ class QualityToolsIntegrationTest {
         htmlReport.shouldExist()
     }
 
-    // Kover
+//    @Test
+//    @DisplayName("should execute kover with defaults")
+//    fun `execute kover with defaults`() {
+//        builder =
+//            TestProjectBuilder
+//                .create("kover-test")
+//                .withVersionCatalog()
+//                .withSettingsGradle()
+//                .withBuildGradle(
+//                    """
+//                    plugins {
+//                        kotlin("jvm")
+//                        id("io.github.aaravmahajanofficial.jenkins-gradle-convention-plugin")
+//                    }
+//
+//                    ${basicPluginConfiguration()}
+//
+//                    testing {
+//                        suites {
+//                            val test by getting(JvmTestSuite::class) {
+//                                useJUnitJupiter()
+//                            }
+//                        }
+//                    }
+//
+//                    """.trimIndent(),
+//                ).withKotlinSource()
+//                .withTestSource(
+//                    language = "kotlin",
+//                    className = "KotlinTestClassTest",
+//                    testClassName = "KotlinTestClass"
+//                )
+//
+//        val tasks = builder.runGradle("tasks", "--all")
+//        println(tasks.output)
+//
+//        val result = builder.runGradle("koverHtmlReport")
+//        result.task(":koverHtmlReport")?.outcome shouldBe TaskOutcome.SUCCESS
+//
+//        println(result.output)
+//
+//        val xmlReport = builder.projectDir.resolve("build/reports/kover/report.xml")
+//        xmlReport.shouldExist()
+//    }
+
     // ESLint
     // Codenarc
 }

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/utils/TestProjectBuilder.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/utils/TestProjectBuilder.kt
@@ -283,8 +283,8 @@ class TestProjectBuilder(
     }
 
     companion object {
-        fun create(name: String = "test-project"): TestProjectBuilder {
-            val tempDir = Files.createTempDirectory("gradle-test-$name-")
+        fun create(): TestProjectBuilder {
+            val tempDir = Files.createTempDirectory("gradle-test-")
             return TestProjectBuilder(tempDir)
         }
 


### PR DESCRIPTION
## Summary

Attempt to fix the build failure (org.jetbrains.kotlin.incremental.classpathDiff.DirectoryOrJar)