### PR TITLE
fix: update Gradle distribution URL and improve artifactId retrieval to remove the config cache bad practice

### DIFF
--- a/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/JenkinsConventionPlugin.kt
+++ b/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/JenkinsConventionPlugin.kt
@@ -55,10 +55,13 @@ public class JenkinsConventionPlugin : Plugin<Project> {
                 group = "Help"
                 description = "Prints the convention plugin configuration."
 
-                t.doLast {
-                    val extension = project.extensions.getByType<PluginExtension>()
+                val artifactId =
+                    project.provider {
+                        extensions.getByType<PluginExtension>().artifactId.orNull
+                    }
 
-                    println("artifactId: ${extension.artifactId.orNull}")
+                t.doLast {
+                    println("artifactId: ${artifactId.get()}")
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Use bin instead of all in distribution URL 